### PR TITLE
Allow the user to specify an encoding

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -67,7 +67,7 @@ Example
     client = Client(host='localhost')
     responses = loop.run_until_complete(asyncio.gather(
         client.ping(),
-        client.check(GTUBE),
-        client.headers(GTUBE)
+        client.check(GTUBE.encode('ascii')),
+        client.headers(GTUBE.encode('ascii'))
     ))
     print(responses)

--- a/aiospamc/client.py
+++ b/aiospamc/client.py
@@ -73,7 +73,8 @@ class Client:
                  user=None,
                  compress=False,
                  ssl=False,
-                 loop=None):
+                 loop=None,
+                 encoding='utf-8'):
         '''Client constructor.
 
         Parameters
@@ -92,6 +93,8 @@ class Client:
             If true, will enable SSL/TLS for the connection.
         loop : :class:`asyncio.AbstractEventLoop`
             The asyncio event loop.
+        encoding : :obj:`str`, optional
+            Encoding (default: 'utf-8').
 
         Raises
         ------
@@ -116,6 +119,7 @@ class Client:
         self.compress = compress
         self._ssl = ssl
         self.loop = loop or asyncio.get_event_loop()
+        self.encoding = encoding
 
         self.parser = parse
 
@@ -128,14 +132,16 @@ class Client:
                       'port={}, '
                       'user={}, '
                       'compress={}, '
-                      'ssl={})')
+                      'ssl={}, '
+                      'encoding={}')
         return client_fmt.format(self.__class__.__name__,
                                  repr(self._socket_path),
                                  repr(self._host),
                                  repr(self._port),
                                  repr(self.user),
                                  repr(self.compress),
-                                 repr(self._ssl))
+                                 repr(self._ssl),
+                                 repr(self.encoding))
 
     @staticmethod
     def _raise_response_exception(response):
@@ -241,7 +247,7 @@ class Client:
 
         try:
             try:
-                response = self.parser(data)
+                response = self.parser(data, encoding=self.encoding)
             except ParseError:
                 raise BadResponse
             self._raise_response_exception(response)
@@ -320,7 +326,7 @@ class Client:
             Timeout during connection.
         '''
 
-        request = Request('CHECK', body=message)
+        request = Request('CHECK', body=message, encoding=self.encoding)
         self.logger.debug('Composed %s request (%s)', request.verb, id(request))
         response = await self.send(request)
 
@@ -386,7 +392,7 @@ class Client:
             Timeout during connection.
         '''
 
-        request = Request('HEADERS', body=message)
+        request = Request('HEADERS', body=message, encoding=self.encoding)
         self.logger.debug('Composed %s request (%s)', request.verb, id(request))
         response = await self.send(request)
 
@@ -442,7 +448,7 @@ class Client:
             Timeout during connection.
         '''
 
-        request = Request('PING')
+        request = Request('PING', encoding=self.encoding)
         self.logger.debug('Composed %s request (%s)', request.verb, id(request))
         response = await self.send(request)
 
@@ -508,7 +514,7 @@ class Client:
             Timeout during connection.
         '''
 
-        request = Request('PROCESS', body=message)
+        request = Request('PROCESS', body=message, encoding=self.encoding)
         self.logger.debug('Composed %s request (%s)', request.verb, id(request))
         response = await self.send(request)
 
@@ -574,7 +580,7 @@ class Client:
             Timeout during connection.
         '''
 
-        request = Request('REPORT', body=message)
+        request = Request('REPORT', body=message, encoding=self.encoding)
         self.logger.debug('Composed %s request (%s)', request.verb, id(request))
         response = await self.send(request)
 
@@ -642,7 +648,7 @@ class Client:
             Timeout during connection.
         '''
 
-        request = Request('REPORT_IFSPAM', body=message)
+        request = Request('REPORT_IFSPAM', body=message, encoding=self.encoding)
         self.logger.debug('Composed %s request (%s)', request.verb, id(request))
         response = await self.send(request)
 
@@ -711,7 +717,7 @@ class Client:
             Timeout during connection.
         '''
 
-        request = Request('SYMBOLS', body=message)
+        request = Request('SYMBOLS', body=message, encoding=self.encoding)
         self.logger.debug('Composed %s request (%s)', request.verb, id(request))
         response = await self.send(request)
 
@@ -791,7 +797,8 @@ class Client:
 
         request = Request(verb='TELL',
                           headers=(MessageClass(message_class),),
-                          body=message)
+                          body=message,
+                          encoding=self.encoding)
         if remove_action:
             request.add_header(Set(remove_action))
         if set_action:

--- a/aiospamc/headers.py
+++ b/aiospamc/headers.py
@@ -44,7 +44,7 @@ class Compress(Header):
         return '{}()'.format(self.__class__.__name__)
 
     def __bytes__(self):
-        return b'%b: zlib\r\n' % (self.field_name().encode())
+        return b'%b: zlib\r\n' % (self.field_name().encode('ascii'))
 
     def field_name(self):
         return 'Compress'
@@ -70,7 +70,7 @@ class ContentLength(Header):
         self.length = length
 
     def __bytes__(self):
-        return b'%b: %d\r\n' % (self.field_name().encode(),
+        return b'%b: %d\r\n' % (self.field_name().encode('ascii'),
                                 self.length)
 
     def __repr__(self):
@@ -101,8 +101,8 @@ class MessageClass(Header):
         self.value = value or MessageClassOption.ham
 
     def __bytes__(self):
-        return b'%b: %b\r\n' % (self.field_name().encode(),
-                                self.value.name.encode())
+        return b'%b: %b\r\n' % (self.field_name().encode('ascii'),
+                                self.value.name.encode('ascii'))
 
     def __repr__(self):
         return '{}(value={})'.format(self.__class__.__name__, str(self.value))
@@ -143,7 +143,7 @@ class _SetRemoveBase(Header):
         if self.action.remote:
             values.append(b'remote')
 
-        return b'%b: %b\r\n' % (self.field_name().encode(),
+        return b'%b: %b\r\n' % (self.field_name().encode('ascii'),
                                 b', '.join(values))
 
     def __repr__(self):
@@ -241,8 +241,8 @@ class Spam(Header):
         self.threshold = threshold
 
     def __bytes__(self):
-        return b'%b: %b ; %.1f / %.1f\r\n' % (self.field_name().encode(),
-                                              str(self.value).encode(),
+        return b'%b: %b ; %.1f / %.1f\r\n' % (self.field_name().encode('ascii'),
+                                              str(self.value).encode('ascii'),
                                               self.score,
                                               self.threshold)
 
@@ -278,8 +278,8 @@ class User(Header):
         self.name = name or getpass.getuser()
 
     def __bytes__(self):
-        return b'%b: %b\r\n' % (self.field_name().encode(),
-                                self.name.encode())
+        return b'%b: %b\r\n' % (self.field_name().encode('ascii'),
+                                self.name.encode('ascii'))
 
     def __repr__(self):
         return '{}(name={})'.format(self.__class__.__name__, repr(self.name))
@@ -315,8 +315,8 @@ class XHeader(Header):
         self.value = value
 
     def __bytes__(self):
-        return b'%b: %b\r\n' % (self.field_name().encode(),
-                                self.value.encode())
+        return b'%b: %b\r\n' % (self.field_name().encode('ascii'),
+                                self.value.encode('ascii'))
 
     def __repr__(self):
         return '{}(name={}, value={})'.format(self.__class__.__name__,

--- a/aiospamc/requests.py
+++ b/aiospamc/requests.py
@@ -19,7 +19,8 @@ class Request(RequestResponseBase):
         :class:`aiospamc.headers.ContentLength` will be automatically added.
     '''
 
-    def __init__(self, verb, version='1.5', headers=None, body=None):
+    def __init__(self, verb, version='1.5', headers=None, body=None,
+            encoding='utf-8'):
         '''Request constructor.
 
         Parameters
@@ -35,17 +36,19 @@ class Request(RequestResponseBase):
             Collection of headers to be added.  If it contains an instance of
             :class:`aiospamc.headers.Compress` then the body is automatically
             compressed.
+        encoding : :obj:`str`, optional
+            Encoding (default: 'utf-8')
         '''
 
         self.verb = verb
         self.version = version
-        super().__init__(body, headers)
+        super().__init__(body, headers, encoding)
 
     def __bytes__(self):
         if self._compressed_body:
             body = self._compressed_body
         elif self.body:
-            body = self.body.encode()
+            body = self.body.encode(self.encoding)
         else:
             body = b''
 
@@ -55,7 +58,7 @@ class Request(RequestResponseBase):
                    b'%(headers)b\r\n'
                    b'%(body)b')
 
-        return request % {b'verb': self.verb.encode(),
-                          b'version': self.version.encode(),
+        return request % {b'verb': self.verb.encode('ascii'),
+                          b'version': self.version.encode('ascii'),
                           b'headers': b''.join(map(bytes, self._headers.values())),
                           b'body': body}

--- a/aiospamc/responses.py
+++ b/aiospamc/responses.py
@@ -63,7 +63,8 @@ class Response(RequestResponseBase):
         Contents of the response body.
     '''
 
-    def __init__(self, version, status_code, message, headers=None, body=None):
+    def __init__(self, version, status_code, message, headers=None, body=None,
+                     encoding='utf-8'):
         '''Response constructor.
 
         Parameters
@@ -81,18 +82,19 @@ class Response(RequestResponseBase):
             Collection of headers to be added.  If it contains an instance of
             :class:`aiospamc.headers.Compress` then the body is automatically
             compressed.
+        encoding : :obj:`str`, optional
+            Name of encoding to use for messages (default: 'utf-8').
         '''
-
         self.version = version
         self.status_code = status_code
         self.message = message
-        super().__init__(body, headers)
+        super().__init__(body, headers, encoding)
 
     def __bytes__(self):
         if self._compressed_body:
             body = self._compressed_body
         elif self.body:
-            body = self.body.encode()
+            body = self.body.encode(self.encoding)
         else:
             body = b''
 
@@ -102,6 +104,6 @@ class Response(RequestResponseBase):
                 b'%(headers)b\r\n'
                 b'%(body)b') % {b'version': b'1.5',
                                 b'status': self.status_code.value,
-                                b'message': self.message.encode(),
+                                b'message': self.message.encode(self.encoding),
                                 b'headers': b''.join(map(bytes, self._headers.values())),
                                 b'body': body}

--- a/example/gtube_example.py
+++ b/example/gtube_example.py
@@ -34,7 +34,7 @@ loop = asyncio.new_event_loop()
 client = Client(host='localhost')
 responses = loop.run_until_complete(asyncio.gather(
     client.ping(),
-    client.check(GTUBE),
-    client.headers(GTUBE)
+    client.check(GTUBE.encode('ascii')),
+    client.headers(GTUBE.encode('ascii'))
 ))
 print(responses)

--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -18,12 +18,23 @@ from aiospamc.responses import Response, Status
 
 def test_client_repr():
     client = Client(host='localhost')
-    assert repr(client) == ('Client(socket_path=\'/var/run/spamassassin/spamd.sock\', '
-                            'host=\'localhost\', '
-                            'port=783, '
-                            'user=None, '
-                            'compress=False, '
-                            'ssl=False)')
+    assert repr(client) == ("Client(socket_path='/var/run/spamassassin/spamd.sock', "
+                            "host='localhost', "
+                            "port=783, "
+                            "user=None, "
+                            "compress=False, "
+                            "ssl=False, "
+                            "encoding='utf-8'")
+
+def test_client_repr_latin_1():
+    client = Client(host='localhost', encoding='latin-1')
+    assert repr(client) == ("Client(socket_path='/var/run/spamassassin/spamd.sock', "
+                            "host='localhost', "
+                            "port=783, "
+                            "user=None, "
+                            "compress=False, "
+                            "ssl=False, "
+                            "encoding='latin-1'")
 
 
 def test_tcp_manager():

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -37,10 +37,10 @@ def test_common_instantiates_with_headers():
 @pytest.mark.parametrize('test_input,headers,expected', [
     (b'Test body\n', [], 'Test body\n'),
     (b'', [], None),
-    (zlib.compress('Test body\n'.encode()), [Compress()], 'Test body\n')
+    (zlib.compress('Test body\n'.encode('ascii')), [Compress()], 'Test body\n')
 ])
 def test_common_parse_body(test_input, headers, expected):
-    body = RequestResponseBase._decode_body(test_input, headers)
+    body = RequestResponseBase._decode_body(test_input, headers, 'ascii')
 
     assert body == expected
 

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -19,16 +19,22 @@ def test_request_instantiates():
     ('TEST', None, []),
     ('TEST', None, [XHeader('X-Tests-Head', 'Tests value')]),
     ('TEST', 'Test body\n', [ContentLength(length=10)]),
-    ('TEST', 'Test body\n', [ContentLength(length=10), Compress()])
+    ('TEST', 'Test body\n', [ContentLength(length=10), Compress()]),
+    ('TEST', b'Binary stuff\n', [ContentLength(length=13)]),
+    ('TEST', b'Really \xbbinary stuff\n', [ContentLength(length=20)]),
 ])
 def test_request_bytes(verb, body, headers):
-    request = Request(verb=verb, body=body, headers=headers)
+    request = Request(verb=verb, body=body, headers=headers, encoding='latin-1')
 
-    assert bytes(request).startswith(verb.encode())
+    assert bytes(request).startswith(verb.encode('ascii'))
     assert bytes(b'SPAMC/1.5\r\n') in bytes(request)
     assert all(bytes(header) in bytes(request) for header in headers)
     if body:
-        if any(isinstance(header, Compress) for header in headers):
-            assert bytes(request).endswith(zlib.compress(body.encode()))
+        if isinstance(body, bytes):
+            bodybytes = body
         else:
-            assert bytes(request).endswith(body.encode())
+            bodybytes = body.encode()
+        if any(isinstance(header, Compress) for header in headers):
+            assert bytes(request).endswith(zlib.compress(bodybytes))
+        else:
+            assert bytes(request).endswith(bodybytes)

--- a/tests/test_responses.py
+++ b/tests/test_responses.py
@@ -32,12 +32,16 @@ def test_response_bytes(version, status, message, body, headers):
                         body=body,
                         headers=headers)
 
-    assert bytes(response).startswith(b'SPAMD/%b' % version.encode())
+    assert bytes(response).startswith(b'SPAMD/%b' % version.encode('ascii'))
     assert b' %d ' % status.value in bytes(response)
-    assert b' %b\r\n' % message.encode() in bytes(response)
+    assert b' %b\r\n' % message.encode('ascii') in bytes(response)
     assert all(bytes(header) in bytes(response) for header in headers)
     if body:
-        if any(isinstance(header, Compress) for header in headers):
-            assert bytes(response).endswith(zlib.compress(body.encode()))
+        if isinstance(body, bytes):
+            bodybytes = body
         else:
-            assert bytes(response).endswith(body.encode())
+            bodybytes = body.encode()
+        if any(isinstance(header, Compress) for header in headers):
+            assert bytes(response).endswith(zlib.compress(bodybytes))
+        else:
+            assert bytes(response).endswith(bodybytes)


### PR DESCRIPTION
This PR contains the beginnings of a change to work around #98 in a backwards-compatible way. I'm not particularly happy with the default `'utf-8'` everywhere -- perhaps it should more clearly discourage this, and eventually require input to be `bytes`.

Consider this work in progress -- feedback would be much appreciated.