### PR TITLE
Fix when spamd returns negative value.

### DIFF
--- a/aiospamc/parser.py
+++ b/aiospamc/parser.py
@@ -257,7 +257,7 @@ class Parser:
             Has the keys `value`, `score`, and `threshold`.
         '''
 
-        number = rb'(\d+(\.\d+)?)'
+        number = rb'(-?\d+(\.\d+)?)'
 
         self.skip(self.whitespace)
         value = True if self.consume(rb'(True|False)').group() == b'True' else False


### PR DESCRIPTION
When SpamAssassin return negative (below 0) score, there is "-" sign at the begining and parser fails returning BadResponse exception.

Is there any logical explanation why should we classify negative score as BadResponse?