### PR TITLE
Pytest TOML configuration

### DIFF
--- a/.azure-pipelines/ci.yaml
+++ b/.azure-pipelines/ci.yaml
@@ -17,8 +17,6 @@ jobs:
 
   strategy:
     matrix:
-      Python35:
-        PythonVersion: '3.5'
       Python36:
         PythonVersion: '3.6'
       Python37:

--- a/.azure-pipelines/templates/ci_steps.yaml
+++ b/.azure-pipelines/templates/ci_steps.yaml
@@ -17,7 +17,7 @@ steps:
   displayName: 'Install dependencies'
 
 - script: |
-    pytest tests/ --junit-xml="$BUILD_STAGINGDIRECTORY/unit-test-results.xml" --cov aiospamc --cov-report="xml:$BUILD_STAGINGDIRECTORY/coverage.xml"
+    pytest --junit-xml="$BUILD_STAGINGDIRECTORY/unit-test-results.xml" --cov --cov-report="xml:$BUILD_STAGINGDIRECTORY/coverage.xml"
   displayName: 'Run unit tests'
 
 - task: PublishTestResults@2
@@ -37,7 +37,7 @@ steps:
   displayName: 'Install SpamAssassin'
 
 - script: |
-    pytest tests/ -m integration --junit-xml="$BUILD_STAGINGDIRECTORY/integration-test-results.xml" --cov aiospamc
+    pytest -m integration --junit-xml="$BUILD_STAGINGDIRECTORY/integration-test-results.xml"
   displayName: 'Run integration tests'
 
 - task: PublishTestResults@2

--- a/aiospamc/__init__.py
+++ b/aiospamc/__init__.py
@@ -26,7 +26,7 @@ __email__ = 'mjcaley@darkarctic.com'
 async def check(
         message: Union[bytes, SupportsBytes],
         *,
-        host: str = 'Localhost',
+        host: str = 'localhost',
         port: int = 783,
         loop: asyncio.AbstractEventLoop = None,
         **kwargs) -> Response:
@@ -72,7 +72,7 @@ async def check(
 async def headers(
         message: Union[bytes, SupportsBytes],
         *,
-        host: str = 'Localhost',
+        host: str = 'localhost',
         port: int = 783,
         loop: asyncio.AbstractEventLoop = None,
         **kwargs) -> Response:
@@ -119,7 +119,7 @@ async def headers(
 
 async def ping(
         *,
-        host: str = 'Localhost',
+        host: str = 'localhost',
         port: int = 783,
         loop: asyncio.AbstractEventLoop = None,
         **kwargs) -> Response:
@@ -162,7 +162,7 @@ async def ping(
 async def process(
         message: Union[bytes, SupportsBytes],
         *,
-        host: str = 'Localhost',
+        host: str = 'localhost',
         port: int = 783,
         loop: asyncio.AbstractEventLoop = None,
         **kwargs) -> Response:
@@ -209,7 +209,7 @@ async def process(
 async def report(
         message: Union[bytes, SupportsBytes],
         *,
-        host: str = 'Localhost',
+        host: str = 'localhost',
         port: int = 783,
         loop: asyncio.AbstractEventLoop = None,
         **kwargs) -> Response:
@@ -255,7 +255,7 @@ async def report(
 async def report_if_spam(
         message: Union[bytes, SupportsBytes],
         *,
-        host: str = 'Localhost',
+        host: str = 'localhost',
         port: int = 783,
         loop: asyncio.AbstractEventLoop = None,
         **kwargs) -> Response:
@@ -301,7 +301,7 @@ async def report_if_spam(
 
 async def symbols(message: Union[bytes, SupportsBytes],
                   *,
-                  host: str = 'Localhost',
+                  host: str = 'localhost',
                   port: int = 783,
                   loop: asyncio.AbstractEventLoop = None,
                   **kwargs) -> Response:
@@ -349,7 +349,7 @@ async def tell(
         message: Union[bytes, SupportsBytes],
         message_class: Union[str, MessageClassOption],
         *,
-        host: str = 'Localhost',
+        host: str = 'localhost',
         port: int = 783,
         remove_action: Union[str, ActionOption] = None,
         set_action: Union[str, ActionOption] = None,

--- a/poetry.lock
+++ b/poetry.lock
@@ -84,6 +84,11 @@ optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, <4"
 version = "5.2.1"
 
+[package.dependencies]
+[package.dependencies.toml]
+optional = true
+version = "*"
+
 [package.extras]
 toml = ["toml"]
 
@@ -508,7 +513,7 @@ docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
 testing = ["pathlib2", "unittest2", "jaraco.itertools", "func-timeout"]
 
 [metadata]
-content-hash = "291efae9052af17f47eb5a1fa52286f65118e5b873fefa6bdab48148078283ea"
+content-hash = "81379ebf4088f0311eaf0671e161a1560294e1adc5b0a2c54de43c6029bda46c"
 lock-version = "1.0"
 python-versions = "^3.6"
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -8,15 +8,6 @@ version = "0.7.12"
 
 [[package]]
 category = "dev"
-description = "Async generators and context managers for Python 3.5+"
-marker = "python_version == \"3.5\""
-name = "async-generator"
-optional = false
-python-versions = ">=3.5"
-version = "1.10"
-
-[[package]]
-category = "dev"
 description = "Enhance the standard unittest package with features for testing asyncio libraries"
 name = "asynctest"
 optional = false
@@ -196,6 +187,19 @@ version = "1.1.1"
 
 [[package]]
 category = "dev"
+description = "Rolling backport of unittest.mock for all Pythons"
+name = "mock"
+optional = false
+python-versions = ">=3.6"
+version = "4.0.2"
+
+[package.extras]
+build = ["twine", "wheel", "blurb"]
+docs = ["sphinx"]
+test = ["pytest", "pytest-cov"]
+
+[[package]]
+category = "dev"
 description = "More routines for operating on iterables, beyond itertools"
 name = "more-itertools"
 optional = false
@@ -212,18 +216,6 @@ version = "20.4"
 
 [package.dependencies]
 pyparsing = ">=2.0.2"
-six = "*"
-
-[[package]]
-category = "dev"
-description = "Object-oriented filesystem paths"
-marker = "python_version < \"3.6\""
-name = "pathlib2"
-optional = false
-python-versions = "*"
-version = "2.3.5"
-
-[package.dependencies]
 six = "*"
 
 [[package]]
@@ -297,10 +289,6 @@ toml = "*"
 python = "<3.8"
 version = ">=0.12"
 
-[package.dependencies.pathlib2]
-python = "<3.6"
-version = ">=2.2.0"
-
 [package.extras]
 checkqa_mypy = ["mypy (0.780)"]
 testing = ["argcomplete", "hypothesis (>=3.56)", "mock", "nose", "requests", "xmlschema"]
@@ -315,10 +303,6 @@ version = "0.14.0"
 
 [package.dependencies]
 pytest = ">=5.4.0"
-
-[package.dependencies.async-generator]
-python = ">=3.5,<3.6"
-version = ">=1.3"
 
 [package.extras]
 testing = ["async-generator (>=1.3)", "coverage", "hypothesis (>=5.7.1)"]
@@ -532,18 +516,14 @@ docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
 testing = ["pathlib2", "unittest2", "jaraco.itertools", "func-timeout"]
 
 [metadata]
-content-hash = "cf38bc00810cbf1c1cfd4ac1bfd86acf06bdf57f054adec6fa9e059e37697dcd"
+content-hash = "ce31e11c3501ba027162a1a4c629b0294c32cb8fd2587dc21917e42d78fcc7cf"
 lock-version = "1.0"
-python-versions = "^3.5"
+python-versions = "^3.6"
 
 [metadata.files]
 alabaster = [
     {file = "alabaster-0.7.12-py2.py3-none-any.whl", hash = "sha256:446438bdcca0e05bd45ea2de1668c1d9b032e1a9154c2c259092d77031ddd359"},
     {file = "alabaster-0.7.12.tar.gz", hash = "sha256:a661d72d58e6ea8a57f7a86e37d86716863ee5e92788398526d58b26a4e4dc02"},
-]
-async-generator = [
-    {file = "async_generator-1.10-py3-none-any.whl", hash = "sha256:01c7bf666359b4967d2cda0000cc2e4af16a0ae098cbffcb8472fb9e8ad6585b"},
-    {file = "async_generator-1.10.tar.gz", hash = "sha256:6ebb3d106c12920aaae42ccb6f787ef5eefdcdd166ea3d628fa8476abe712144"},
 ]
 asynctest = [
     {file = "asynctest-0.13.0-py3-none-any.whl", hash = "sha256:5da6118a7e6d6b54d83a8f7197769d046922a44d2a99c21382f0a6e4fadae676"},
@@ -719,6 +699,10 @@ markupsafe = [
     {file = "MarkupSafe-1.1.1-cp38-cp38-win_amd64.whl", hash = "sha256:e8313f01ba26fbbe36c7be1966a7b7424942f670f38e666995b88d012765b9be"},
     {file = "MarkupSafe-1.1.1.tar.gz", hash = "sha256:29872e92839765e546828bb7754a68c418d927cd064fd4708fab9fe9c8bb116b"},
 ]
+mock = [
+    {file = "mock-4.0.2-py3-none-any.whl", hash = "sha256:3f9b2c0196c60d21838f307f5825a7b86b678cedc58ab9e50a8988187b4d81e0"},
+    {file = "mock-4.0.2.tar.gz", hash = "sha256:dd33eb70232b6118298d516bbcecd26704689c386594f0f3c4f13867b2c56f72"},
+]
 more-itertools = [
     {file = "more-itertools-8.4.0.tar.gz", hash = "sha256:68c70cc7167bdf5c7c9d8f6954a7837089c6a36bf565383919bb595efb8a17e5"},
     {file = "more_itertools-8.4.0-py3-none-any.whl", hash = "sha256:b78134b2063dd214000685165d81c154522c3ee0a1c0d4d113c80361c234c5a2"},
@@ -726,10 +710,6 @@ more-itertools = [
 packaging = [
     {file = "packaging-20.4-py2.py3-none-any.whl", hash = "sha256:998416ba6962ae7fbd6596850b80e17859a5753ba17c32284f67bfff33784181"},
     {file = "packaging-20.4.tar.gz", hash = "sha256:4357f74f47b9c12db93624a82154e9b120fa8293699949152b22065d556079f8"},
-]
-pathlib2 = [
-    {file = "pathlib2-2.3.5-py2.py3-none-any.whl", hash = "sha256:0ec8205a157c80d7acc301c0b18fbd5d44fe655968f5d947b6ecef5290fc35db"},
-    {file = "pathlib2-2.3.5.tar.gz", hash = "sha256:6cd9a47b597b37cc57de1c05e56fb1a1c9cc9fab04fe78c29acd090418529868"},
 ]
 pluggy = [
     {file = "pluggy-0.13.1-py2.py3-none-any.whl", hash = "sha256:966c145cd83c96502c3c3868f50408687b38434af77734af1e9ca461a4081d2d"},

--- a/poetry.lock
+++ b/poetry.lock
@@ -8,14 +8,6 @@ version = "0.7.12"
 
 [[package]]
 category = "dev"
-description = "Enhance the standard unittest package with features for testing asyncio libraries"
-name = "asynctest"
-optional = false
-python-versions = ">=3.5"
-version = "0.13.0"
-
-[[package]]
-category = "dev"
 description = "Atomic file writes."
 marker = "sys_platform == \"win32\""
 name = "atomicwrites"
@@ -516,7 +508,7 @@ docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
 testing = ["pathlib2", "unittest2", "jaraco.itertools", "func-timeout"]
 
 [metadata]
-content-hash = "ce31e11c3501ba027162a1a4c629b0294c32cb8fd2587dc21917e42d78fcc7cf"
+content-hash = "291efae9052af17f47eb5a1fa52286f65118e5b873fefa6bdab48148078283ea"
 lock-version = "1.0"
 python-versions = "^3.6"
 
@@ -524,10 +516,6 @@ python-versions = "^3.6"
 alabaster = [
     {file = "alabaster-0.7.12-py2.py3-none-any.whl", hash = "sha256:446438bdcca0e05bd45ea2de1668c1d9b032e1a9154c2c259092d77031ddd359"},
     {file = "alabaster-0.7.12.tar.gz", hash = "sha256:a661d72d58e6ea8a57f7a86e37d86716863ee5e92788398526d58b26a4e4dc02"},
-]
-asynctest = [
-    {file = "asynctest-0.13.0-py3-none-any.whl", hash = "sha256:5da6118a7e6d6b54d83a8f7197769d046922a44d2a99c21382f0a6e4fadae676"},
-    {file = "asynctest-0.13.0.tar.gz", hash = "sha256:c27862842d15d83e6a34eb0b2866c323880eb3a75e4485b079ea11748fd77fac"},
 ]
 atomicwrites = [
     {file = "atomicwrites-1.4.0-py2.py3-none-any.whl", hash = "sha256:6d1784dea7c0c8d4a5172b6c620f40b6e4cbfdf96d783691f2e1302a7b88e197"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,6 @@ python = "^3.6"
 certifi = "^2020.6"
 
 [tool.poetry.dev-dependencies]
-asynctest = "^0.13.0"
 pytest = "^6.0"
 pytest-cov = "^2.10"
 pytest-asyncio = "^0.14.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,15 @@ markers = ["integration: spawn an instance of spamd and test against it"]
 addopts = "-m \"not integration\""
 mock_use_standalone_module = true
 
+[tool.coverage.run]
+branch = true
+
+[tool.coverage.report]
+exclude_lines = [
+    "pragma: no cover",
+    "def __repr__"
+]
+
 [tool.poetry.dependencies]
 python = "^3.6"
 certifi = "^2020.6"
@@ -44,6 +53,7 @@ sphinx = "^3.1"
 pytest-mock = "^3.2"
 cryptography = "^3.0"
 mock = "^4.0.2"
+coverage = {extras = ["toml"], version = "^5.2"}
 
 [build-system]
 requires = ["poetry>=1.0"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,14 @@ classifiers = [
 
 keywords = ["spam", "spamc", "spamassassin"]
 
+[tool.pytest.ini_options]
+minversion = "6.0"
+testpaths = [
+    "tests"
+]
+markers = ["integration: spawn an instance of spamd and test against it"]
+addopts = "-m \"not integration\""
+
 [tool.poetry.dependencies]
 python = "^3.5"
 certifi = "^2020.6"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,6 @@ homepage = "https://github.com/mjcaley/aiospamc"
 
 classifiers = [
     'Development Status :: 4 - Beta',
-    'Programming Language :: Python :: 3.5',
     'Programming Language :: Python :: 3.6',
     'Programming Language :: Python :: 3.7',
     'Programming Language :: Python :: 3.8',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,7 @@ pytest-asyncio = "^0.14.0"
 sphinx = "^3.1"
 pytest-mock = "^3.2"
 cryptography = "^3.0"
-mock = "^4.0.2"
+mock = "^4.0"
 coverage = {extras = ["toml"], version = "^5.2"}
 
 [build-system]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,10 +29,11 @@ testpaths = [
     "tests"
 ]
 markers = ["integration: spawn an instance of spamd and test against it"]
-addopts = "-m \"not integration\""
+addopts = "-m \"not integration\" --cov"
 mock_use_standalone_module = true
 
 [tool.coverage.run]
+source = ["aiospamc"]
 branch = true
 
 [tool.coverage.report]
@@ -40,6 +41,7 @@ exclude_lines = [
     "pragma: no cover",
     "def __repr__"
 ]
+fail_under = 90.0
 
 [tool.poetry.dependencies]
 python = "^3.6"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ testpaths = [
     "tests"
 ]
 markers = ["integration: spawn an instance of spamd and test against it"]
-addopts = "-m \"not integration\" --cov"
+addopts = "-m \"not integration\""
 mock_use_standalone_module = true
 
 [tool.coverage.run]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,9 +30,10 @@ testpaths = [
 ]
 markers = ["integration: spawn an instance of spamd and test against it"]
 addopts = "-m \"not integration\""
+mock_use_standalone_module = true
 
 [tool.poetry.dependencies]
-python = "^3.5"
+python = "^3.6"
 certifi = "^2020.6"
 
 [tool.poetry.dev-dependencies]
@@ -43,6 +44,7 @@ pytest-asyncio = "^0.14.0"
 sphinx = "^3.1"
 pytest-mock = "^3.2"
 cryptography = "^3.0"
+mock = "^4.0.2"
 
 [build-system]
 requires = ["poetry>=1.0"]

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,0 @@
-[pytest]
-markers =
-    integration: spawn an instance of spamd and test against it
-addopts = -m "not integration"

--- a/tests/connections/conftest.py
+++ b/tests/connections/conftest.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 
 import pytest
-from asynctest import CoroutineMock, MagicMock
 
 
 @pytest.fixture
@@ -11,17 +10,17 @@ def address():
 
 @pytest.fixture
 def open_connection(mocker):
-    yield mocker.patch('asyncio.open_connection', CoroutineMock(return_value=(MagicMock(), MagicMock())))
+    yield mocker.patch('asyncio.open_connection', mocker.AsyncMock(return_value=(mocker.MagicMock(), mocker.MagicMock())))
 
 
 @pytest.fixture
 def connection_refused(mocker):
-    yield mocker.patch('asyncio.open_connection', CoroutineMock(side_effect=ConnectionRefusedError))
+    yield mocker.patch('asyncio.open_connection', mocker.AsyncMock(side_effect=ConnectionRefusedError))
 
 
 @pytest.fixture
 def os_error(mocker):
-    yield mocker.patch('asyncio.open_connection', CoroutineMock(side_effect=OSError))
+    yield mocker.patch('asyncio.open_connection', mocker.AsyncMock(side_effect=OSError))
 
 
 @pytest.fixture
@@ -31,14 +30,14 @@ def unix_socket():
 
 @pytest.fixture
 def open_unix_connection(mocker):
-    yield mocker.patch('asyncio.open_unix_connection', CoroutineMock(return_value=(MagicMock(), MagicMock())))
+    yield mocker.patch('asyncio.open_unix_connection', mocker.AsyncMock(return_value=(mocker.MagicMock(), mocker.MagicMock())))
 
 
 @pytest.fixture
 def unix_connection_refused(mocker):
-    yield mocker.patch('asyncio.open_unix_connection', CoroutineMock(side_effect=ConnectionRefusedError))
+    yield mocker.patch('asyncio.open_unix_connection', mocker.AsyncMock(side_effect=ConnectionRefusedError))
 
 
 @pytest.fixture
 def unix_os_error(mocker):
-    yield mocker.patch('asyncio.open_unix_connection', CoroutineMock(side_effect=OSError))
+    yield mocker.patch('asyncio.open_unix_connection', mocker.AsyncMock(side_effect=OSError))

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -4,7 +4,6 @@ from pathlib import Path
 import ssl
 
 import pytest
-from asynctest import CoroutineMock
 
 import certifi
 
@@ -308,10 +307,10 @@ async def test_response_general_exception(stub_connection_manager, ex_undefined,
 @pytest.mark.asyncio
 async def test_requests_with_body(verb, method, spam, mocker):
     c = Client()
-    c.send = CoroutineMock()
+    mocker.patch('aiospamc.client.Client.send')
     mocker.spy(c, 'send')
     await getattr(c, method)(spam)
-    request = c.send.call_args[0][0]
+    request = c.send.await_args[0][0]
 
     assert request.verb == verb
     assert request.body == spam
@@ -320,10 +319,10 @@ async def test_requests_with_body(verb, method, spam, mocker):
 @pytest.mark.asyncio
 async def test_request_ping(mocker):
     c = Client()
-    c.send = CoroutineMock()
+    mocker.patch('aiospamc.client.Client.send')
     mocker.spy(c, 'send')
     await c.ping()
-    request = c.send.call_args[0][0]
+    request = c.send.await_args[0][0]
 
     assert request.verb == 'PING'
 
@@ -342,10 +341,10 @@ async def test_request_ping(mocker):
 @pytest.mark.asyncio
 async def test_request_tell(message_class, remove_action, set_action, spam, mocker):
     c = Client()
-    c.send = CoroutineMock()
+    mocker.patch('aiospamc.client.Client.send')
     mocker.spy(c, 'send')
     await c.tell(message=spam, message_class=message_class, remove_action=remove_action, set_action=set_action)
-    request = c.send.call_args[0][0]
+    request = c.send.await_args[0][0]
 
     assert request.headers['Message-class'].value == message_class
     if remove_action:

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -7,33 +7,88 @@ import aiospamc
 from aiospamc.client import Client
 
 
-@pytest.mark.asyncio
-@pytest.mark.parametrize('method', [
-    'check',
-    'headers',
-    'process',
-    'report',
-    'report_if_spam',
-    'symbols'
-])
-async def test_frontend_function_with_message(mocker, method, spam):
-    mock = mocker.patch.object(Client, method, new=CoroutineMock())
-    func = getattr(aiospamc, method)
-    result = await func(spam)
-
-    assert result
-    assert mock.called
-    assert result is mock.return_value
+@pytest.fixture
+def mock_client_cls(mocker):
+    client_cls = mocker.patch('aiospamc.Client', autospec=True)
+    yield client_cls
 
 
 @pytest.mark.asyncio
-async def test_ping(mocker):
-    mock = mocker.patch.object(Client, 'ping', new=CoroutineMock())
+async def test_check_default_args_passed(mocker, mock_client_cls, spam):
+    await aiospamc.check(spam)
+
+    assert 'localhost' == mock_client_cls.call_args.kwargs['host']
+    assert 783 == mock_client_cls.call_args.kwargs['port']
+
+
+@pytest.mark.asyncio
+async def test_check(mocker, mock_client_cls, spam):
+    mocker.spy(aiospamc, 'client')
+    result = await aiospamc.check(spam)
+
+    assert result is mock_client_cls.return_value.check.return_value
+    assert spam is mock_client_cls.return_value.check.await_args.args[0]
+
+
+@pytest.mark.asyncio
+async def test_headers_default_args_passed(mocker, mock_client_cls, spam):
+    await aiospamc.headers(spam)
+
+    assert 'localhost' == mock_client_cls.call_args.kwargs['host']
+    assert 783 == mock_client_cls.call_args.kwargs['port']
+
+
+@pytest.mark.asyncio
+async def test_headers(mocker, mock_client_cls, spam):
+    mocker.spy(aiospamc, 'headers')
+    result = await aiospamc.headers(spam)
+
+    assert result is mock_client_cls.return_value.headers.return_value
+    assert spam is mock_client_cls.return_value.headers.await_args.args[0]
+
+
+@pytest.mark.asyncio
+async def test_ping_default_args_passed(mocker, mock_client_cls):
+    await aiospamc.ping()
+
+    assert 'localhost' == mock_client_cls.call_args.kwargs['host']
+    assert 783 == mock_client_cls.call_args.kwargs['port']
+
+
+@pytest.mark.asyncio
+async def test_ping(mock_client_cls):
     result = await aiospamc.ping()
 
-    assert result
-    assert mock.called
-    assert result is mock.return_value
+    assert result is mock_client_cls.return_value.ping.return_value
+
+
+@pytest.mark.asyncio
+async def test_process_default_args_passed(mocker, mock_client_cls, spam):
+    await aiospamc.process(spam)
+
+    assert 'localhost' == mock_client_cls.call_args.kwargs['host']
+    assert 783 == mock_client_cls.call_args.kwargs['port']
+
+
+@pytest.mark.asyncio
+async def test_process(mocker, mock_client_cls, spam):
+    mocker.spy(aiospamc, 'process')
+    result = await aiospamc.process(spam)
+
+    assert result is mock_client_cls.return_value.process.return_value
+    assert spam is mock_client_cls.return_value.process.await_args.args[0]
+
+
+@pytest.mark.asyncio
+async def test_tell_default_args_passed(mocker, mock_client_cls, spam):
+    await aiospamc.tell(
+        spam,
+        message_class=mocker.Mock(),
+        set_action=mocker.Mock(),
+        remove_action=mocker.Mock())
+
+    assert 'localhost' == mock_client_cls.call_args.kwargs['host']
+    assert 783 == mock_client_cls.call_args.kwargs['port']
 
 
 @pytest.mark.asyncio
@@ -45,8 +100,9 @@ async def test_ping(mocker):
     ['spam', aiospamc.ActionOption(local=True, remote=False), 'local,remote'],
     ['spam', 'local,remote', aiospamc.ActionOption(local=True, remote=False)],
 ])
-async def test_tell(mocker, spam, message_class, remove_action, set_action):
-    mock = mocker.patch.object(Client, 'tell', new=CoroutineMock())
+async def test_tell(mocker, mock_client_cls, spam, message_class, remove_action, set_action):
+    mock_instance = mock_client_cls.return_value
+
     result = await aiospamc.tell(
         spam,
         message_class=message_class,
@@ -54,6 +110,8 @@ async def test_tell(mocker, spam, message_class, remove_action, set_action):
         set_action=set_action
     )
 
-    assert result
-    assert mock.called
-    assert result is mock.return_value
+    assert result is mock_instance.tell.return_value
+    assert spam == mock_instance.tell.await_args.kwargs['message']
+    assert message_class == mock_instance.tell.await_args.kwargs['message_class']
+    assert remove_action == mock_instance.tell.await_args.kwargs['remove_action']
+    assert set_action == mock_instance.tell.await_args.kwargs['set_action']

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -79,6 +79,57 @@ async def test_process(mocker, mock_client_cls, spam):
 
 
 @pytest.mark.asyncio
+async def test_report_default_args_passed(mocker, mock_client_cls, spam):
+    await aiospamc.report(spam)
+
+    assert 'localhost' == mock_client_cls.call_args.kwargs['host']
+    assert 783 == mock_client_cls.call_args.kwargs['port']
+
+
+@pytest.mark.asyncio
+async def test_report(mocker, mock_client_cls, spam):
+    mocker.spy(aiospamc, 'client')
+    result = await aiospamc.report(spam)
+
+    assert result is mock_client_cls.return_value.report.return_value
+    assert spam is mock_client_cls.return_value.report.await_args.args[0]
+
+
+@pytest.mark.asyncio
+async def test_report_if_spam_default_args_passed(mocker, mock_client_cls, spam):
+    await aiospamc.report_if_spam(spam)
+
+    assert 'localhost' == mock_client_cls.call_args.kwargs['host']
+    assert 783 == mock_client_cls.call_args.kwargs['port']
+
+
+@pytest.mark.asyncio
+async def test_report_if_spam(mocker, mock_client_cls, spam):
+    mocker.spy(aiospamc, 'client')
+    result = await aiospamc.report_if_spam(spam)
+
+    assert result is mock_client_cls.return_value.report_if_spam.return_value
+    assert spam is mock_client_cls.return_value.report_if_spam.await_args.args[0]
+
+
+@pytest.mark.asyncio
+async def test_symbols_default_args_passed(mocker, mock_client_cls, spam):
+    await aiospamc.symbols(spam)
+
+    assert 'localhost' == mock_client_cls.call_args.kwargs['host']
+    assert 783 == mock_client_cls.call_args.kwargs['port']
+
+
+@pytest.mark.asyncio
+async def test_symbols(mocker, mock_client_cls, spam):
+    mocker.spy(aiospamc, 'client')
+    result = await aiospamc.symbols(spam)
+
+    assert result is mock_client_cls.return_value.symbols.return_value
+    assert spam is mock_client_cls.return_value.symbols.await_args.args[0]
+
+
+@pytest.mark.asyncio
 async def test_tell_default_args_passed(mocker, mock_client_cls, spam):
     await aiospamc.tell(
         spam,

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 
 import pytest
-from asynctest import CoroutineMock
 
 import aiospamc
 from aiospamc.client import Client


### PR DESCRIPTION
* Moved pytest configuration to pyproject.toml
* Removed asynctest library and use the mock library
* Added coverage configuration to pyproject.toml
* Removed support for Python 3.5 (limited by mock library and will be end-of-life soon)
* Fixes #214 