### PR TITLE
Remov loop parameter

### DIFF
--- a/aiospamc/__init__.py
+++ b/aiospamc/__init__.py
@@ -28,14 +28,12 @@ async def check(
         *,
         host: str = 'localhost',
         port: int = 783,
-        loop: asyncio.AbstractEventLoop = None,
         **kwargs) -> Response:
     '''Checks a message if it's spam and return a response with a score header.
 
     :param message: Copy of the message.
     :param host: Hostname or IP address of the SPAMD service, defaults to localhost.
     :param port: Port number for the SPAMD service, defaults to 783.
-    :param loop: The asyncio event loop.
     :param kwargs:
         Additional options to pass to the :class:`aiospamc.client.Client` instance.
 
@@ -63,7 +61,7 @@ async def check(
     :raises TimeoutException: Timeout during connection.
     '''
 
-    c = Client(host=host, port=port, **kwargs, loop=loop)
+    c = Client(host=host, port=port, **kwargs)
     response = await c.check(message)
 
     return response
@@ -74,14 +72,12 @@ async def headers(
         *,
         host: str = 'localhost',
         port: int = 783,
-        loop: asyncio.AbstractEventLoop = None,
         **kwargs) -> Response:
     '''Checks a message if it's spam and return the modified message headers.
 
     :param message: Copy of the message.
     :param host: Hostname or IP address of the SPAMD service, defaults to localhost.
     :param port: Port number for the SPAMD service, defaults to 783.
-    :param loop: The asyncio event loop.
     :param kwargs:
         Additional options to pass to the :class:`aiospamc.client.Client`
         instance.
@@ -111,7 +107,7 @@ async def headers(
     :raises TimeoutException: Timeout during connection.
     '''
 
-    c = Client(host=host, port=port, **kwargs, loop=loop)
+    c = Client(host=host, port=port, **kwargs)
     response = await c.headers(message)
 
     return response
@@ -121,13 +117,11 @@ async def ping(
         *,
         host: str = 'localhost',
         port: int = 783,
-        loop: asyncio.AbstractEventLoop = None,
         **kwargs) -> Response:
     '''Sends a ping to the SPAMD service.
 
     :param host: Hostname or IP address of the SPAMD service, defaults to localhost.
     :param port: Port number for the SPAMD service, defaults to 783.
-    :param loop: The asyncio event loop.
     :param kwargs:
         Additional options to pass to the :class:`aiospamc.client.Client` instance.
 
@@ -153,7 +147,7 @@ async def ping(
     :raises TimeoutException: Timeout during connection.
     '''
 
-    c = Client(host=host, port=port, **kwargs, loop=loop)
+    c = Client(host=host, port=port, **kwargs)
     response = await c.ping()
 
     return response
@@ -164,14 +158,12 @@ async def process(
         *,
         host: str = 'localhost',
         port: int = 783,
-        loop: asyncio.AbstractEventLoop = None,
         **kwargs) -> Response:
     '''Checks a message if it's spam and return a response with a score header.
 
     :param message: Copy of the message.
     :param host: Hostname or IP address of the SPAMD service, defaults to localhost.
     :param port: Port number for the SPAMD service, defaults to 783.
-    :param loop: The asyncio event loop.
     :param kwargs:
         Additional options to pass to the :class:`aiospamc.client.Client` instance.
 
@@ -200,7 +192,7 @@ async def process(
     :raises TimeoutException: Timeout during connection.
     '''
 
-    c = Client(host=host, port=port, **kwargs, loop=loop)
+    c = Client(host=host, port=port, **kwargs)
     response = await c.process(message)
 
     return response
@@ -211,14 +203,12 @@ async def report(
         *,
         host: str = 'localhost',
         port: int = 783,
-        loop: asyncio.AbstractEventLoop = None,
         **kwargs) -> Response:
     '''Checks a message if it's spam and return a response with a score header.
 
     :param message: Copy of the message.
     :param host: Hostname or IP address of the SPAMD service, defaults to localhost.
     :param port: Port number for the SPAMD service, defaults to 783.
-    :param loop: The asyncio event loop.
     :param kwargs:
         Additional options to pass to the :class:`aiospamc.client.Client` instance.
 
@@ -246,7 +236,7 @@ async def report(
     :raises TimeoutException: Timeout during connection.
     '''
 
-    c = Client(host=host, port=port, **kwargs, loop=loop)
+    c = Client(host=host, port=port, **kwargs)
     response = await c.report(message)
 
     return response
@@ -257,14 +247,12 @@ async def report_if_spam(
         *,
         host: str = 'localhost',
         port: int = 783,
-        loop: asyncio.AbstractEventLoop = None,
         **kwargs) -> Response:
     '''Checks a message if it's spam and return a response with a score header.
 
     :param message: Copy of the message.
     :param host: Hostname or IP address of the SPAMD service, defaults to localhost.
     :param port: Port number for the SPAMD service, defaults to 783.
-    :param loop: The asyncio event loop.
     :param kwargs:
         Additional options to pass to the :class:`aiospamc.client.Client` instance.
 
@@ -293,7 +281,7 @@ async def report_if_spam(
     :raises TimeoutException: Timeout during connection.
     '''
 
-    c = Client(host=host, port=port, **kwargs, loop=loop)
+    c = Client(host=host, port=port, **kwargs)
     response = await c.report_if_spam(message)
 
     return response
@@ -310,7 +298,6 @@ async def symbols(message: Union[bytes, SupportsBytes],
     :param message: Copy of the message.
     :param host: Hostname or IP address of the SPAMD service, defaults to localhost.
     :param port: Port number for the SPAMD service, defaults to 783.
-    :param loop: The asyncio event loop.
     :param kwargs:
         Additional options to pass to the :class:`aiospamc.client.Client` instance.
 
@@ -339,7 +326,7 @@ async def symbols(message: Union[bytes, SupportsBytes],
     :raises TimeoutException: Timeout during connection.
     '''
 
-    c = Client(host=host, port=port, **kwargs, loop=loop)
+    c = Client(host=host, port=port, **kwargs)
     response = await c.symbols(message)
 
     return response
@@ -353,7 +340,6 @@ async def tell(
         port: int = 783,
         remove_action: Union[str, ActionOption] = None,
         set_action: Union[str, ActionOption] = None,
-        loop: asyncio.AbstractEventLoop = None,
         **kwargs) -> Response:
     '''Checks a message if it's spam and return a response with a score header.
 
@@ -364,7 +350,6 @@ async def tell(
     :param remove_action: Remove message class for message in database.
     :param set_action:
         Set message class for message in database.  Either `ham` or `spam`.
-    :param loop: The asyncio event loop.
     :param kwargs:
         Additional options to pass to the :class:`aiospamc.client.Client` instance.
 
@@ -392,7 +377,7 @@ async def tell(
     :raises TimeoutException: Timeout during connection.
     '''
 
-    c = Client(host=host, port=port, **kwargs, loop=loop)
+    c = Client(host=host, port=port, **kwargs)
     response = await c.tell(
         message=message,
         message_class=message_class,

--- a/aiospamc/client.py
+++ b/aiospamc/client.py
@@ -26,8 +26,7 @@ class Client:
                  port: int = 783,
                  user: str = None,
                  compress: bool = False,
-                 verify: Union[bool, str, Path] = None,
-                 loop: asyncio.AbstractEventLoop = None) -> None:
+                 verify: Union[bool, str, Path] = None) -> None:
         '''Client constructor.
 
         :param socket_path: The path to the Unix socket for the SPAMD service.
@@ -38,20 +37,19 @@ class Client:
         :param verify: Use SSL for the connection.  If True, will use root certificates.
             If False, will not verify the certificate.  If a string to a path or a Path
             object, the connection will use the certificates found there.
-        :param loop: The asyncio event loop.
 
         :raises ValueError: Raised if the constructor can't tell if it's using a TCP or a Unix domain socket connection.
         '''
 
         if socket_path:
             from aiospamc.connections.unix_connection import UnixConnectionManager
-            self.connection = UnixConnectionManager(socket_path, loop=loop)
+            self.connection = UnixConnectionManager(socket_path)
         elif host and port:
             from aiospamc.connections.tcp_connection import TcpConnectionManager
             if verify is not None:
-                self.connection = TcpConnectionManager(host, port, self.new_ssl_context(verify), loop=loop)
+                self.connection = TcpConnectionManager(host, port, self.new_ssl_context(verify))
             else:
-                self.connection = TcpConnectionManager(host, port, loop=loop)
+                self.connection = TcpConnectionManager(host, port)
         else:
             raise ValueError('Either "host" and "port" or "socket_path" must be specified.')
 

--- a/aiospamc/connections/__init__.py
+++ b/aiospamc/connections/__init__.py
@@ -10,14 +10,10 @@ from typing import Tuple, Union, SupportsBytes
 class Connection:
     '''Base class for connection objects.'''
 
-    def __init__(self, loop: asyncio.AbstractEventLoop = None):
-        '''Connection constructor.
-
-        :param loop: The asyncio event loop.
-        '''
+    def __init__(self):
+        '''Connection constructor.'''
 
         self.connected = False
-        self.loop = loop or asyncio.get_event_loop()
         self.logger = logging.getLogger(__name__)
 
     async def __aenter__(self):
@@ -67,9 +63,6 @@ class Connection:
 
 class ConnectionManager:
     '''Stores connection parameters and creates connections.'''
-
-    def __init__(self, loop: asyncio.AbstractEventLoop = None):
-        self.loop = loop or asyncio.get_event_loop()
 
     def new_connection(self) -> Connection:
         '''Creates a connection object.'''

--- a/aiospamc/connections/tcp_connection.py
+++ b/aiospamc/connections/tcp_connection.py
@@ -14,19 +14,18 @@ from ..exceptions import AIOSpamcConnectionFailed
 class TcpConnectionManager(ConnectionManager):
     '''Creates new connections based on host and port provided.'''
 
-    def __init__(self, host: str, port: int, ssl: SSLContext = None, loop: asyncio.AbstractEventLoop = None) -> None:
+    def __init__(self, host: str, port: int, ssl: SSLContext = None) -> None:
         '''Constructor for TcpConnectionManager.
 
         :param host: Hostname or IP address of server.
         :param port: Port number
         :param ssl: SSL/TLS context.
-        :param loop: The asyncio event loop.
         '''
 
         self.host = host
         self.port = port
         self.ssl = ssl
-        super().__init__(loop)
+        super().__init__()
 
     def __repr__(self) -> str:
         return '{}(host={}, port={}, ssl={})'.format(self.__class__.__name__,
@@ -40,13 +39,13 @@ class TcpConnectionManager(ConnectionManager):
         :raises AIOSpamcConnectionFailed:
         '''
 
-        return TcpConnection(self.host, self.port, self.ssl, self.loop)
+        return TcpConnection(self.host, self.port, self.ssl)
 
 
 class TcpConnection(Connection):
     '''Manages a TCP connection.'''
 
-    def __init__(self, host: str, port: int, ssl: SSLContext = None, loop: asyncio.AbstractEventLoop = None):
+    def __init__(self, host: str, port: int, ssl: SSLContext = None):
         '''Constructor for TcpConnection.
 
         :param host: Hostname or IP address of server.
@@ -57,7 +56,7 @@ class TcpConnection(Connection):
         self.host = host
         self.port = port
         self.ssl = ssl
-        super().__init__(loop)
+        super().__init__()
 
     def __repr__(self) -> str:
         return '{}(host={}, port={}, ssl={})'.format(self.__class__.__name__,
@@ -75,8 +74,7 @@ class TcpConnection(Connection):
 
             reader, writer = await asyncio.open_connection(self.host,
                                                            self.port,
-                                                           ssl=self.ssl,
-                                                           loop=self.loop)
+                                                           ssl=self.ssl)
         except (ConnectionRefusedError, OSError) as error:
             raised = AIOSpamcConnectionFailed(error)
             self.logger.exception('Exception occurred when connecting to %s:%s: %s',

--- a/aiospamc/connections/unix_connection.py
+++ b/aiospamc/connections/unix_connection.py
@@ -13,15 +13,14 @@ from ..exceptions import AIOSpamcConnectionFailed
 class UnixConnectionManager(ConnectionManager):
     '''Creates new connections based on Unix domain socket path provided.'''
 
-    def __init__(self, path: str, loop: asyncio.AbstractEventLoop = None) -> None:
+    def __init__(self, path: str) -> None:
         '''Constructor for UnixConnectionManager.
 
         :param path: Path of the socket.
-        :param loop: The asyncio event loop.
         '''
 
         self.path = path
-        super().__init__(loop)
+        super().__init__()
 
     def __repr__(self) -> str:
         return 'UnixConnectionManager(path={})'.format(repr(self.path))
@@ -32,21 +31,20 @@ class UnixConnectionManager(ConnectionManager):
         :raises AIOSpamcConnectionFailed:
         '''
 
-        return UnixConnection(self.path, self.loop)
+        return UnixConnection(self.path)
 
 
 class UnixConnection(Connection):
     '''Manages a Unix domain socket connection.'''
 
-    def __init__(self, path: str, loop: asyncio.AbstractEventLoop = None) -> None:
+    def __init__(self, path: str) -> None:
         '''Constructor for UnixConnection.
 
         :param path: Path of the socket.
-        :param loop: The asyncio event loop.
         '''
 
         self.path = path
-        super().__init__(loop)
+        super().__init__()
 
     def __repr__(self) -> str:
         return 'UnixConnection(path={})'.format(repr(self.path))
@@ -58,8 +56,7 @@ class UnixConnection(Connection):
         '''
 
         try:
-            reader, writer = await asyncio.open_unix_connection(self.path,
-                                                                loop=self.loop)
+            reader, writer = await asyncio.open_unix_connection(self.path)
         except (ConnectionRefusedError, OSError) as error:
             raised = AIOSpamcConnectionFailed(error)
             self.logger.exception('Exception occurred when connecting: %s', raised)

--- a/tests/connections/test_tcp_connection.py
+++ b/tests/connections/test_tcp_connection.py
@@ -23,16 +23,6 @@ def test_instantiates_with_ssl(address, mocker):
     assert conn.ssl is ssl_stub
 
 
-def test_instantiates_with_loop(address, event_loop):
-    conn = TcpConnection(host=address[0],
-                         port=address[1],
-                         loop=event_loop)
-
-    assert conn.host is address[0]
-    assert conn.port is address[1]
-    assert conn.loop is event_loop
-
-
 def test_repr(address):
     conn = TcpConnection(host=address[0], port=address[1])
 

--- a/tests/connections/test_tcp_connection_manager.py
+++ b/tests/connections/test_tcp_connection_manager.py
@@ -21,14 +21,6 @@ def test_instantiates_with_ssl(address, mocker):
     assert conn_man.ssl is ssl_stub
 
 
-def test_instantiates_with_loop(address, event_loop):
-    conn_man = TcpConnectionManager(host=address[0], port=address[1], loop=event_loop)
-
-    assert conn_man.host is address[0]
-    assert conn_man.port is address[1]
-    assert conn_man.loop is event_loop
-
-
 def test_repr(address):
     conn_man = TcpConnectionManager(address[0], address[1])
 

--- a/tests/connections/test_unix_connection.py
+++ b/tests/connections/test_unix_connection.py
@@ -14,13 +14,6 @@ def test_instantiates(unix_socket):
     assert conn.path is unix_socket
 
 
-def test_instantiates_with_loop(unix_socket, event_loop):
-    conn = UnixConnection(unix_socket, event_loop)
-
-    assert conn.path is unix_socket
-    assert conn.loop is event_loop
-
-
 def test_repr(unix_socket):
     conn = UnixConnection(unix_socket)
 

--- a/tests/connections/test_unix_connection_manager.py
+++ b/tests/connections/test_unix_connection_manager.py
@@ -11,13 +11,6 @@ def test_instantiates(unix_socket):
     assert conn_man.path is unix_socket
 
 
-def test_instantiates_with_loop(unix_socket, event_loop):
-    conn_man = UnixConnectionManager(unix_socket, event_loop)
-
-    assert conn_man.path is unix_socket
-    assert conn_man.loop is event_loop
-
-
 def test_repr(unix_socket):
     conn_man = UnixConnectionManager(unix_socket)
 


### PR DESCRIPTION
Loop parameter is deprecated in Python 3.8, so we're removing it now.  Fixes #213