### PR TITLE
Fixes #233

### DIFF
--- a/aiospamc/connections.py
+++ b/aiospamc/connections.py
@@ -66,11 +66,9 @@ class ConnectionManager:
         reader, writer = await self._connect()
 
         writer.write(data)
-        await writer.drain()
         if writer.can_write_eof():
             writer.write_eof()
-        else:
-            writer.write(b"\x00")
+        await writer.drain()
 
         response = await self._receive(reader)
 

--- a/aiospamc/connections.py
+++ b/aiospamc/connections.py
@@ -67,6 +67,10 @@ class ConnectionManager:
 
         writer.write(data)
         await writer.drain()
+        if writer.can_write_eof():
+            writer.write_eof()
+        else:
+            writer.write(b"\x00")
 
         response = await self._receive(reader)
 

--- a/tests/integration/test_ssl.py
+++ b/tests/integration/test_ssl.py
@@ -81,3 +81,11 @@ async def test_tell(spamd, spam):
     )
 
     assert result
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_message_without_newline(spamd):
+    result = await aiospamc.check(message=b'acb', host=spamd['tcp']['host'], port=spamd['tcp']['port'])
+
+    assert result

--- a/tests/integration/test_tcp.py
+++ b/tests/integration/test_tcp.py
@@ -72,3 +72,11 @@ async def test_tell(spamd, spam):
     )
 
     assert result
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_message_without_newline(spamd):
+    result = await aiospamc.check(message=b'acb', host=spamd['tcp']['host'], port=spamd['tcp']['port'])
+
+    assert result

--- a/tests/integration/test_unix.py
+++ b/tests/integration/test_unix.py
@@ -67,3 +67,11 @@ async def test_tell(spamd, spam):
     result = await aiospamc.tell(message=spam, message_class='spam', socket_path=spamd['unix']['socket'])
 
     assert result
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_message_without_newline(spamd):
+    result = await aiospamc.check(message=b'acb', host=spamd['tcp']['host'], port=spamd['tcp']['port'])
+
+    assert result


### PR DESCRIPTION
Send an EOF to connections that support it
If EOF isn't supported, send a null byte