### PR TITLE
Fix documentaton formatting and references

### DIFF
--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -366,8 +366,8 @@ Environment Variables
 Exit Codes
 **********
 
-`3` - Error occurred when parsing response.
-`4` - Network timeout.
-`5` - Connection error. Check the host, port, or socket path.
-`6` - Unexpected error.
-`7` - Could not open the message.
+* `3` - Error occurred when parsing response.
+* `4` - Network timeout.
+* `5` - Connection error. Check the host, port, or socket path.
+* `6` - Unexpected error.
+* `7` - Could not open the message.

--- a/docs/library.rst
+++ b/docs/library.rst
@@ -123,3 +123,6 @@ Interpreting results
 
 Responses are encapsulated in the :class:`aiospamc.responses.Response` class.
 It includes the status code, headers and body.
+
+The :class:`aiospamc.headers.Headers` class provides properties for headers defined in the
+protocol.

--- a/docs/library.rst
+++ b/docs/library.rst
@@ -55,6 +55,7 @@ Client Certificate Authentication
 
 Client certificate authentication can be used with SSL. It's driven through the `cert`
 parameter on frontend functions. The parameter value takes three forms:
+
 * A path to a file expecting the certificate and key in the PEM format
 * A tuple of certificate and key files
 * A tuple of certificate file, key file, and password if the key is encrypted

--- a/docs/protocol.rst
+++ b/docs/protocol.rst
@@ -721,5 +721,5 @@ that was sent.
 References
 **********
 
-.. [1] https://svn.apache.org/viewvc/spamassassin/branches/3.4/spamd/PROTOCOL?revision=1676616&view=co
-.. [2] https://svn.apache.org/viewvc/spamassassin/branches/3.4/spamd/spamd.raw?revision=1749346&view=co
+.. [1] https://svn.apache.org/viewvc/spamassassin/tags/spamassassin_release_4_0_1/spamd/PROTOCOL?view=co
+.. [2] https://svn.apache.org/viewvc/spamassassin/tags/spamassassin_release_4_0_1/spamd/spamd.raw?view=co


### PR DESCRIPTION
- Fixed formatting for lists in documentation
- Updated references for protocol documentation
- Mentioned Headers class in the user guide to encourage use
